### PR TITLE
Fix Telegram action log

### DIFF
--- a/spidermon/contrib/actions/telegram/__init__.py
+++ b/spidermon/contrib/actions/telegram/__init__.py
@@ -25,7 +25,7 @@ class SimplyTelegramClient:
         )
         r = requests.get(api_url).json()
         if r.get("ok") is False:
-            logger.error("Failed to send message. Telegram api error: %s", r.text)
+            logger.error("Failed to send message. Telegram api error: %s", r.description)
 
 
 class TelegramMessageManager:

--- a/spidermon/contrib/actions/telegram/__init__.py
+++ b/spidermon/contrib/actions/telegram/__init__.py
@@ -25,7 +25,9 @@ class SimplyTelegramClient:
         )
         r = requests.get(api_url).json()
         if r.get("ok") is False:
-            logger.error("Failed to send message. Telegram api error: %s", r.description)
+            logger.error(
+                "Failed to send message. Telegram api error: %s", r.description
+            )
 
 
 class TelegramMessageManager:


### PR DESCRIPTION
If the request sent to Telegram throw an error the following dict is returned: 

```
{'ok': False, 'error_code': 400, 'description': 'Bad Request: chat not found'}
```

Currently, Spidermon is calling the key `text` instead of `description` in order to add details to the logs, which is causing the following error:

```
ERROR: SendTelegramMessageSpiderFinished
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ana/workspace/xxx/venv/lib/python3.8/site-packages/spidermon/core/actions.py", line 37, in run
    self.run_action()
  File "/home/ana/workspace/xxx/venv/lib/python3.8/site-packages/spidermon/contrib/actions/telegram/__init__.py", line 94, in run_action
  File "/home/ana/workspace/xxx/venv/lib/python3.8/site-packages/spidermon/contrib/actions/telegram/__init__.py", line 48, in send_message
  File "/home/ana/workspace/xxx/venv/lib/python3.8/site-packages/spidermon/contrib/actions/telegram/__init__.py", line 28, in send_message
    logger.error("Failed to send message. Telegram api error: %s", r.text)
AttributeError: 'dict' object has no attribute 'text'
```

**Version:** Spidermon 1.12.0